### PR TITLE
Cancel the autocomplete search action on paper-chip-input-autocomplet…

### DIFF
--- a/paper-chip-input-autocomplete.html
+++ b/paper-chip-input-autocomplete.html
@@ -92,6 +92,7 @@ Custom property | Description | Default
 		</style>
 
 		<iron-a11y-keys target="paperInput" keys="backspace" on-keys-pressed="_onKeyBackspace"></iron-a11y-keys>
+		<iron-a11y-keys target="paperInput" keys="esc" on-keys-pressed="_onKeyEsc"></iron-a11y-keys>
 
 		<div>
 			<paper-input id="paperInput" label="[[label]]" on-keyup="_findItems" value="{{_inputValue}}" autofocus="{{autofocus}}">
@@ -210,6 +211,12 @@ Custom property | Description | Default
 					(this._inputValue == '' || this._inputValue == undefined)) {
 					this._removeLastItem();
 				}
+			}
+
+			_onKeyEsc(event) {
+				this._inputValue = '';
+				this._hideAutocomplete();
+				this.$.paperInput.focus();
 			}
 
 			_removeLastItem() {


### PR DESCRIPTION
When I start searching with the paper-chip-input-autocomplete I didn't find a easy way to cancel my action.
I think that pressing the ESC key should clear my input and close any suggestions.